### PR TITLE
isstring in style to force type of cell to string

### DIFF
--- a/myexcel.js
+++ b/myexcel.js
@@ -180,8 +180,9 @@ $JExcel = {
         return (row[x] ? row[x] : setV(row, x, {}));
     }
 
-    function setCell(cell, value, style) {
+    function setCell(cell, value, style, isstring) {
         if (value != undefined) cell.v = value;
+        cell.isstring = isstring;
         if (style) cell.s = style;
     }
 
@@ -389,7 +390,7 @@ $JExcel = {
 
         var oStyles = {
             add: function (a) {
-                var style = {};
+                var style = {isstring: a.isstring};
                 if (a.fill && a.fill.charAt(0) == "#") style.fill = 2 + findOrAdd(fills, a.fill.toString().substring(1).toUpperCase());                  // If there is a fill color add it, with a gap of 2, because of the TWO DEFAULT HARDCODED fills
                 if (a.font) style.font = findOrAdd(fonts, normalizeFont(a.font.toString().trim()));
                 if (a.format) style.format = findOrAdd(formats, a.format);
@@ -497,8 +498,8 @@ $JExcel = {
         if (cell.s) s = s + ' s="' + cell.s + '" ';
         
 		var value=cell.v;
-		if (isNaN(value)) {
-			if (value.charAt(0)!='=') return s + ' t="inlineStr" ><is><t>' + escape(value) + '</t></is></c>';
+		if (cell.isstring || isNaN(value)) {
+			if (cell.isstring || value.charAt(0)!='=') return s + ' t="inlineStr" ><is><t>' + escape(value) + '</t></is></c>';
 			return s+' ><f>'+value.substring(1)+'</f></c>';
         }
 		return s + '><v>' + value + '</v></c>';
@@ -623,7 +624,10 @@ $JExcel = {
             s = sheets.get(s);
             if (isNaN(column) && isNaN(row)) return s.set(value, style);                                                            // If this is a sheet operation
             if (!isNaN(column)) {                                                                                                    // If this is a column operation
-                if (!isNaN(row)) return setCell(s.getCell(column, row), value, style);                                                // and also a ROW operation the this is a CELL operation
+                if (!isNaN(row)) {
+                    var isstring = style && styles.getStyle(style-1).isstring;
+                    return setCell(s.getCell(column, row), value, style, isstring);                                                // and also a ROW operation the this is a CELL operation
+                }
                 return setColumn(s.getColumn(column), value, style);                                                                // if not we confirm than this is a COLUMN operation
             }
             return setRow(s.getRow(row), value, style);                                                                             // If got here, thet this is a Row operation

--- a/simpletest.html
+++ b/simpletest.html
@@ -1,0 +1,43 @@
+<html lang="en">
+  <head>
+    <script type="text/javascript" src="jszip.js"></script>
+    <script type="text/javascript" src="FileSaver.js"></script>
+    <script type="text/javascript" src="myexcel.js"></script>
+    <script>
+      "use strict";
+
+      function go() {
+      var excel = $JExcel.new("Calibri light 10 #333333");
+      var textStyle = excel.addStyle({align: "L", format: "@"});
+      var zeroStyle = excel.addStyle({align: "L", format: "0"});
+      var isstringStyle = excel.addStyle({align: "L", format: "@", isstring: true});
+
+      excel.set(0,0,1, "01234567890123456789 with format @", textStyle);
+      excel.set(0,1,1, "01234567890123456789", textStyle);
+      
+      excel.set(0,0,2, "01234567890123456789 with format 0", textStyle);
+      excel.set(0,1,2, "01234567890123456789", zeroStyle);
+
+      excel.set(0,0,3, "012345678901234 with format @", textStyle);
+      excel.set(0,1,3, "012345678901234", textStyle);
+
+      excel.set(0,0,4, "012345678901234 with format 0", textStyle);
+      excel.set(0,1,4, "012345678901234", zeroStyle);
+
+      excel.set(0,0,5, "01234567890123456789, format @ and isstring=true", textStyle);
+      excel.set(0,1,5, "01234567890123456789", isstringStyle);
+
+      excel.set(0,0,6, " =1+2, format=@");
+      excel.set(0,1,6, "=1+2", textStyle);
+
+      excel.set(0,0,7, " =1+2, format=@, isstring=true", isstringStyle);
+      excel.set(0,1,7, "=1+2", isstringStyle);
+
+      excel.generate("TestData.xlsx");
+      }
+    </script>
+  </head>
+  <body>
+    <a href="#" onclick="go();">Simple Test GO</a>
+  </body>
+</html>


### PR DESCRIPTION
Hello jsegarray1971,
I had problems with integers that were formatted as 1.23434e9 and leading zeros in cells, like 0986123456,
the 0 was dropped.
So I added the property isstring to styles which forces the cell to be generated as string. 
Only the style which is set directly on the cell is considered.

