### PR TITLE
Improve performance using style.key

### DIFF
--- a/myexcel.js
+++ b/myexcel.js
@@ -134,7 +134,7 @@ $JExcel = {
     }
 
     function pushI(list, value) {
-        list.push(value);
+        list.push(value); 
         return list.length - 1;
     }
 
@@ -333,7 +333,7 @@ $JExcel = {
         if ((style.fill || 0) != 0) s = s + ' applyFill="1" ';
         if ((alignXml || "") != "") s = s + ' applyAlignment="1" ';
         s = s + '>';
-        s = s + alignXml;
+        s = s + alignXml; 
         return s + "</xf>";
     }
 


### PR DESCRIPTION
Hi,

I noticed poor performance in large sheets (when formatting cells and columns with  `excel.addStyle(s)`. The suggested changes reduce file size and improve performance by limiting the number of styles to be created & exported.

In addition, the style xml ( `<xf` ) contains many times 'undefined' instead of the defaults like Excel does (0). Not sure if this is a problem, at least it helps reducing the file size.

Best regards,
Erik
