### PR TITLE
Freeze panes

### DIFF
--- a/myexcel.js
+++ b/myexcel.js
@@ -22,23 +22,23 @@ $JExcel = {
         return (componentToHex(r) + componentToHex(g) + componentToHex(b)).toUpperCase();
     }
 
-	$JExcel.toExcelUTCTime = function (date1){
-		var d2=Math.floor(date1.getTime()/1000);													// Number of seconds since JS epoch
-		d2=Math.floor(d2/86400)+25569;																// Days since epoch plus difference in days between Excel EPOCH and JS epoch
-		
-		var seconds = date1.getUTCSeconds()+60*date1.getUTCMinutes()+60*60*date1.getUTCHours();		// Number of seconds of received hour
-		var SECS_DAY= 60 * 60 * 24;																	// Number of seconds of a day
-		return d2+(seconds/SECS_DAY);																// Returns a local time !!
-	}
+    $JExcel.toExcelUTCTime = function (date1) {
+        var d2 = Math.floor(date1.getTime() / 1000);													// Number of seconds since JS epoch
+        d2 = Math.floor(d2 / 86400) + 25569;																// Days since epoch plus difference in days between Excel EPOCH and JS epoch
 
-	$JExcel.toExcelLocalTime = function (date1){
-		var d2=Math.floor(date1.getTime()/1000);													// Number of seconds since JS epoch
-		d2=Math.floor(d2/86400)+25569;																// Days since epoch plus difference in days between Excel EPOCH and JS epoch
-		var seconds = date1.getUTCSeconds()+60*date1.getUTCMinutes()+60*60*date1.getUTCHours();		// Number of seconds of received hour
-		seconds = seconds-60*(date1.getTimezoneOffset());											// Differences in seconds between UTC and LOCAL this depends on date becase daylight saving time
-		var SECS_DAY= 60 * 60 * 24;																	// Number of seconds of a day
-		return d2+(seconds/SECS_DAY);																// Returns a local time !!
-	}
+        var seconds = date1.getUTCSeconds() + 60 * date1.getUTCMinutes() + 60 * 60 * date1.getUTCHours();		// Number of seconds of received hour
+        var SECS_DAY = 60 * 60 * 24;																	// Number of seconds of a day
+        return d2 + (seconds / SECS_DAY);																// Returns a local time !!
+    }
+
+    $JExcel.toExcelLocalTime = function (date1) {
+        var d2 = Math.floor(date1.getTime() / 1000);													// Number of seconds since JS epoch
+        d2 = Math.floor(d2 / 86400) + 25569;																// Days since epoch plus difference in days between Excel EPOCH and JS epoch
+        var seconds = date1.getUTCSeconds() + 60 * date1.getUTCMinutes() + 60 * 60 * date1.getUTCHours();		// Number of seconds of received hour
+        seconds = seconds - 60 * (date1.getTimezoneOffset());											// Differences in seconds between UTC and LOCAL this depends on date becase daylight saving time
+        var SECS_DAY = 60 * 60 * 24;																	// Number of seconds of a day
+        return d2 + (seconds / SECS_DAY);																// Returns a local time !!
+    }
 
     // For styles see page 2127-2143 of the standard at
     // http://www.ecma-international.org/news/TC45_current_work/Office%20Open%20XML%20Part%204%20-%20Markup%20Language%20Reference.pdf
@@ -107,12 +107,12 @@ $JExcel = {
 
 
     var templateSheet = '<?xml version="1.0" ?><worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" ' +
-                'xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" xmlns:mv="urn:schemas-microsoft-com:mac:vml" ' +
-                'xmlns:mx="http://schemas.microsoft.com/office/mac/excel/2008/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" ' +
-                'xmlns:x14="http://schemas.microsoft.com/office/spreadsheetml/2009/9/main" xmlns:x14ac="http://schemas.microsoft.com/office/spreadsheetml/2009/9/ac" ' +
-                'xmlns:xm="http://schemas.microsoft.com/office/excel/2006/main">' +
-                '{columns}' +
-                '<sheetData>{rows}</sheetData></worksheet>';
+        'xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" xmlns:mv="urn:schemas-microsoft-com:mac:vml" ' +
+        'xmlns:mx="http://schemas.microsoft.com/office/mac/excel/2008/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" ' +
+        'xmlns:x14="http://schemas.microsoft.com/office/spreadsheetml/2009/9/main" xmlns:x14ac="http://schemas.microsoft.com/office/spreadsheetml/2009/9/ac" ' +
+        'xmlns:xm="http://schemas.microsoft.com/office/excel/2006/main">' +
+        '{views}{columns}' +
+        '<sheetData>{rows}</sheetData></worksheet>';
 
 
     // --------------------- BEGIN of generic UTILS
@@ -158,7 +158,7 @@ $JExcel = {
 
 
     function getAsXml(sheet) {
-        return templateSheet.replace('{columns}', generateColums(sheet.columns)).replace("{rows}", generateRows(sheet.rows));
+        return templateSheet.replace('{views}', generateViews(sheet.views)).replace('{columns}', generateColums(sheet.columns)).replace("{rows}", generateRows(sheet.rows));
     }
 
 
@@ -196,6 +196,13 @@ $JExcel = {
         if (style) row.style = style;
     }
 
+    function freezePane(x, y) {
+        var pane = { topLeftCell: cellName(x, y) };
+        if (x >= 0) { pane.xSplit = x; }
+        if (y >= 0) { pane.ySplit = y - 1; } 
+        var view = { panes: [pane] };
+        view.workbookViewId = pushI(this.views, view);
+    }
     // ------------------- END Sheet DATA Handling
 
 
@@ -203,7 +210,7 @@ $JExcel = {
         var oSheets = {
             sheets: [],
             add: function (name) {
-                var sheet = { id: this.sheets.length + 1, rId: "rId" + (3 + this.sheets.length), name: name, rows: [], columns: [], getColumn: getColumn, set: setSheet, getRow: getRow, getCell: getCell };
+                var sheet = { id: this.sheets.length + 1, rId: "rId" + (3 + this.sheets.length), name: name, rows: [], columns: [], views: [], getColumn: getColumn, set: setSheet, getRow: getRow, getCell: getCell, freezePane: freezePane };
                 return pushI(this.sheets, sheet);
             },
             get: function (index) {
@@ -307,26 +314,31 @@ $JExcel = {
         return where;
     }
 
+    function createKey(style) {
+        if (!style.key) {
+            style.key = JSON.stringify(style);
+        }
+    }
 
     function toStyleXml(style) {
         var alignXml = "";
         if (style.align) {
             var h = align[style.align.charAt(0)];
             var v = align[style.align.charAt(1)];
-	        var w = align[style.align.charAt(2)];
+            var w = align[style.align.charAt(2)];
             if (h || v || w) {
                 alignXml = "<alignment ";
                 if (h) alignXml = alignXml + ' horizontal="' + h + '" ';
                 if (v) alignXml = alignXml + ' vertical="' + v + '" ';
-				if (w) alignXml = alignXml + ' ' + w + '="1" ';
+                if (w) alignXml = alignXml + ' ' + w + '="1" ';
                 alignXml = alignXml + " />";
             }
         }
-        var s = '<xf numFmtId="' + style.format + '" fontId="' + style.font + '" fillId="' + style.fill + '" borderId="' + style.border + '" xfId="0" ';
-        if (style.border != 0) s = s + ' applyBorder="1" ';
+        var s = '<xf numFmtId="' + (style.format || 0) + '" fontId="' + (style.font || 0) + '" fillId="' + (style.fill || 0) + '" borderId="' + (style.border || 0) + '" xfId="0" ';
+        if ((style.border || 0) != 0) s = s + ' applyBorder="1" ';
         if (style.format >= baseFormats) s = s + ' applyNumberFormat="1" ';
-        if (style.fill != 0) s = s + ' applyFill="1" ';
-        if (alignXml != "") s = s + ' applyAlignment="1" ';
+        if ((style.fill || 0) != 0) s = s + ' applyFill="1" ';
+        if ((alignXml || "") != "") s = s + ' applyAlignment="1" ';
         s = s + '>';
         s = s + alignXml;
         return s + "</xf>";
@@ -364,7 +376,7 @@ $JExcel = {
     function normalizeAlign(a) {
         if (!a) return "---";
         var a = replaceAllMultiple(a.toString() + " - - -", "  ", " ").trim().toUpperCase().split(" ");
-        return a[0].charAt(0) + a[1].charAt(0)  + a[2].charAt(0);
+        return a[0].charAt(0) + a[1].charAt(0) + a[2].charAt(0);
     }
 
     function normalizeBorders(b) {
@@ -390,23 +402,30 @@ $JExcel = {
 
         var oStyles = {
             add: function (a) {
-                var style = {isstring: a.isstring};
+                var style = { isstring: a.isstring };
                 if (a.fill && a.fill.charAt(0) == "#") style.fill = 2 + findOrAdd(fills, a.fill.toString().substring(1).toUpperCase());                  // If there is a fill color add it, with a gap of 2, because of the TWO DEFAULT HARDCODED fills
                 if (a.font) style.font = findOrAdd(fonts, normalizeFont(a.font.toString().trim()));
                 if (a.format) style.format = findOrAdd(formats, a.format);
                 if (a.align) style.align = normalizeAlign(a.align);
                 if (a.border) style.border = 1 + findOrAdd(borders, normalizeBorders(a.border.toString().trim()));                                          // There is a HARDCODED border         
+
+                createKey(style);
+                for (var i = styles.length - 1; i >= 0; i--) {
+                    if (styles[i].key == style.key) return 1 + i;
+                }
                 return 1 + pushI(styles, style);                                                            // Add the style and return INDEX+1 because of the DEFAULT HARDCODED style
             }
         };
 
-        if (!defaultFont) defaultFont="Calibri Light 12 0000EE";
+        if (!defaultFont) defaultFont = "Calibri Light 12 0000EE";
         oStyles.add({ font: defaultFont });
 
 
         oStyles.register = function (thisOne) {
-            for (var i = 0; i < styles.length; i++) {
-                if (styles[i].font == thisOne.font && styles[i].format == thisOne.format && styles[i].fill == thisOne.fill && styles[i].border == thisOne.border && styles[i].align == thisOne.align) return i;
+            createKey(thisOne);
+
+            for (var i = styles.length - 1; i >= 0; i--) {
+                if (styles[i].key == thisOne.key) return i;
             }
             return pushI(styles, thisOne);
         }
@@ -416,7 +435,7 @@ $JExcel = {
         }
         oStyles.toStyleSheet = function () {
             var s = '<?xml version="1.0" encoding="utf-8"?><styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" ' +
-                    'xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" mc:Ignorable="x14ac" xmlns:x14ac="http://schemas.microsoft.com/office/spreadsheetml/2009/9/ac">';
+                'xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" mc:Ignorable="x14ac" xmlns:x14ac="http://schemas.microsoft.com/office/spreadsheetml/2009/9/ac">';
 
             s = s + '<numFmts count="' + (formats.length - baseFormats) + '">';
             for (var i = baseFormats; i < formats.length; i++) s = s + '<numFmt numFmtId="' + (i) + '" formatCode="' + formats[i] + '"/>';
@@ -479,30 +498,30 @@ $JExcel = {
         if (typeof string != 'string') string = null ? '' : (string + '');
 
         return (string && reHasUnescapedHtml.test(string))
-          ? string.replace(reUnescapedHtml, escapeHtmlChar)
-          : string;
+            ? string.replace(reUnescapedHtml, escapeHtmlChar)
+            : string;
     }
-	
-	function cellNameH(i) {
-		var rest = Math.floor(i / 26) - 1; 
-		var s = (rest > -1 ? cellNameH(rest) : '');
-		return  s+ "ABCDEFGHIJKLMNOPQRSTUVWXYZ".charAt(i % 26); 
-	}
+
+    function cellNameH(i) {
+        var rest = Math.floor(i / 26) - 1;
+        var s = (rest > -1 ? cellNameH(rest) : '');
+        return s + "ABCDEFGHIJKLMNOPQRSTUVWXYZ".charAt(i % 26);
+    }
 
     function cellName(colIndex, rowIndex) {
-        return cellNameH(colIndex)+rowIndex;
+        return cellNameH(colIndex) + rowIndex;
     };
 
     function generateCell(cell, column, row) {
         var s = '<c r="' + cellName(column, row) + '"';
         if (cell.s) s = s + ' s="' + cell.s + '" ';
-        
-		var value=cell.v;
-		if (cell.isstring || isNaN(value)) {
-			if (cell.isstring || value.charAt(0)!='=') return s + ' t="inlineStr" ><is><t>' + escape(value) + '</t></is></c>';
-			return s+' ><f>'+value.substring(1)+'</f></c>';
+
+        var value = cell.v;
+        if (cell.isstring || isNaN(value)) {
+            if (cell.isstring || value.charAt(0) != '=') return s + ' t="inlineStr" ><is><t>' + escape(value) + '</t></is></c>';
+            return s + ' ><f>' + value.substring(1) + '</f></c>';
         }
-		return s + '><v>' + value + '</v></c>';
+        return s + '><v>' + value + '</v></c>';
     }
 
     function generateRow(row, index) {
@@ -526,6 +545,33 @@ $JExcel = {
             }
         }
         return oRows.join('');
+    }
+
+    function generateViews(views) {
+        if (views.length == 0) return;
+       
+        var s = '<sheetViews>';
+        for (var i = 0; i < views.length; i++) {
+            var c = views[i];
+            if (c && c.panes && c.panes.length) {
+                s += '<sheetView workbookViewId="' + (c.workbookViewId || i) + '">';
+                for (var p = 0; p < c.panes.length; p++) {
+                    var pane = c.panes[p];
+                    s += '<pane state="frozen" topLeftCell="' + pane.topLeftCell + '"';
+                    if (pane.xSplit) {
+                        s += ' xSplit="' + pane.xSplit + '"';
+                    }
+                    if (pane.ySplit) {
+                        s += ' ySplit="' + pane.ySplit + '"';
+                    }
+                    s += '/>';
+                }
+                s += '</sheetView>';
+            }
+        }
+        s += "</sheetViews>";
+        console.log(s);
+        return s;
     }
 
     function generateColums(columns) {
@@ -554,7 +600,7 @@ $JExcel = {
     //  If a row has a style it tries to apply the style componenets to all cells in the row (provided that the cell has not defined is not own style component)
 
     function CombineStyles(sheets, styles) {
-        // First lets do the Rows
+        // First lets do the sheets
         for (var i = 0; i < sheets.length; i++) {
             // First let's do the rows
             for (var j = 0; j < sheets[i].rows.length; j++) {
@@ -597,6 +643,7 @@ $JExcel = {
             }
         }
         if (!b) return;                                         // If the toAdd style does NOT add anything new
+        delete ns.key; // the key should be recalculated, remove the key from any of the origin objects
         cell.s = 1 + styles.register(ns);
     }
 
@@ -625,12 +672,16 @@ $JExcel = {
             if (isNaN(column) && isNaN(row)) return s.set(value, style);                                                            // If this is a sheet operation
             if (!isNaN(column)) {                                                                                                    // If this is a column operation
                 if (!isNaN(row)) {
-                    var isstring = style && styles.getStyle(style-1).isstring;
+                    var isstring = style && styles.getStyle(style - 1).isstring;
                     return setCell(s.getCell(column, row), value, style, isstring);                                                // and also a ROW operation the this is a CELL operation
                 }
                 return setColumn(s.getColumn(column), value, style);                                                                // if not we confirm than this is a COLUMN operation
             }
             return setRow(s.getRow(row), value, style);                                                                             // If got here, thet this is a Row operation
+        }
+
+        excel.freezePane = function (s, x, y) {
+            sheets.get(s).freezePane(x, y);
         }
 
         excel.generate = function (filename) {
@@ -643,9 +694,9 @@ $JExcel = {
             xl.file('_rels/workbook.xml.rels', sheets.toWorkBookRels());                                        // Add WorkBook RELs
             zip.file('[Content_Types].xml', sheets.toContentType());                                            // Add content types
             sheets.fileData(xl);                                                                                // Zip the rest    
-            zip.generateAsync({ type: "blob",mimeType:"application/vnd.ms-excel" }).then(function (content) { saveAs(content, filename); });        // And generate !!!
-       
-	}
+            zip.generateAsync({ type: "blob", mimeType: "application/vnd.ms-excel" }).then(function (content) { saveAs(content, filename); });        // And generate !!!
+
+        }
         return excel;
     }
 })();


### PR DESCRIPTION
var sheet = 0;
var row = 0;
var column = 2; //to freeze A2, first row.
 excel.freezePane(sheet, row, column);

1. Please note that I commited this file after adding performance improvemetns (see other pull request)
2. Please note that my editor changed some other layout details that can/should be ignored. 

Relevant lines (in new code):
- line 114 (modified)     '{views}{columns}' +
- line 161 (modified)     return templateSheet.replace('{views}', .....
- lines 199-205 (added) function freezePane(x, y) 
- line 213 (modified)   var sheet = {
- lines 550-576 (added)  function generateViews(views) {
- lines 683 - 686 (added) excel.freezePane = function (s, x, y) {
appologies for the confusion, I never did a fork/pull request before..
