### PR TITLE
Supporting firefox

### DIFF
--- a/myexcel.js
+++ b/myexcel.js
@@ -712,7 +712,7 @@ $JExcel = {
             xl.file('_rels/workbook.xml.rels', sheets.toWorkBookRels());                                        // Add WorkBook RELs
             zip.file('[Content_Types].xml', sheets.toContentType());                                            // Add content types
             sheets.fileData(xl);                                                                                // Zip the rest    
-            zip.generateAsync({ type: "blob",mimeType:"application/vnd.ms-excel" }).then(function (content) { saveAs(content, filename); });        // And generate !!!
+            zip.generateAsync({ type: "blob",mimeType:"application/vnd.ms-excel,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" }).then(function (content) { saveAs(content, filename); });        // And generate !!!
        
 	}
         return excel;


### PR DESCRIPTION
I was using FF 61.0.1 to generate an excel file with the '.xlsx' extension. When trying to open it directly FF wants to change the extension back to 'xls'. At the end I got 'file.xlsx-1.xls' instead of 'file.xlsx' which pops up a warning in Excel (2013). This fix just extends the mime type to support '.xlsx' and so allows FF to open it without warning.